### PR TITLE
fix: error when creating cloudwatch logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_kms_key" "encryption_key" {
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = var.logs_path
   retention_in_days = var.log_group_retention_in_days
-  kms_key_id        = var.create_kms_key ? aws_kms_key.encryption_key[0].key_id : var.log_group_kms_key_id
+  kms_key_id        = var.create_kms_key ? aws_kms_key.encryption_key[0].arn : var.log_group_kms_key_id
   tags              = var.tags
 }
 


### PR DESCRIPTION
when create_kms_key enabled, it should be arn not the key id to be referenced to the cloudwatch log group block